### PR TITLE
Add brOscat lib to the README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,8 @@ A curated list of awesome [B&amp;R](https://www.br-automation.com)  frameworks, 
 ### Mathematics
 * [RandomLib](https://github.com/brownNinja17/RandomLib) - RandomLib is an Automation Studio library to generate random data.
 
+### Community libraries
+* [brOscatLib](https://github.com/tkucic/brOscatLib) - B&R Automation studio port of the popular Oscat libraries
 
 ---
 


### PR DESCRIPTION
I started porting the Oscat lib (www.oscat.de) and initial scripted porting has been completed.  Currently I am working on manually fixing the syntax errors and problems. Help is appreciated as there are 748 really useful POUs for maths, logic operation etc.